### PR TITLE
Fix duplicate parameters when using ?page_size=

### DIFF
--- a/angular-django-rest-resource.js
+++ b/angular-django-rest-resource.js
@@ -353,6 +353,7 @@ angular.module('djangoRESTResources', ['ng']).
                     // If there is a next page, go ahead and request it before parsing our results. Less wasted time.
                     if (data.next !== null) {
                       var next_config = copy(httpConfig);
+                      next_config.params = {};
                       next_config.url = data.next;
                       $http(next_config).success(function(next_data) { recursivePaginator(next_data); }).error(error);
                     }


### PR DESCRIPTION
DRF automatically includes ?page_size etc in the next URL, so adding them manually results in duplicate parameters in url.

eg.
/api/feed/?custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&custom_filter=true&page=10&page_size=5&page_size=5&page_size=5&page_size=5&page_size=5&page_size=5&page_size=5&page_size=5&page_size=5&custom_filter=true&page_size=5
