### PR TITLE
port numbers in urls don't have to be escaped

### DIFF
--- a/angular-django-rest-resource.js
+++ b/angular-django-rest-resource.js
@@ -36,8 +36,7 @@
  *
  * @param {string} url A parametrized URL template with parameters prefixed by `:` as in
  *   `/user/:username`. If you are using a URL with a port number (e.g.
- *   `http://example.com:8080/api`), you'll need to escape the colon character before the port
- *   number, like this: `djResource('http://example.com\\:8080/api')`.
+ *   `http://example.com:8080/api`), it will be respected.
  *
  * @param {Object=} paramDefaults Default values for `url` parameters. These can be overridden in
  *   `actions` methods. If any of the parameter value is a function, it will be executed every time
@@ -215,7 +214,7 @@ angular.module('djangoRESTResources', ['ng']).
 
         var urlParams = self.urlParams = {};
         forEach(url.split(/\W/), function(param){
-          if (param && (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
+          if (!(new RegExp("^\\d+$").test(param)) && param && (new RegExp("(^|[^\\\\]):" + param + "(\\W|$)").test(url))) {
               urlParams[param] = true;
           }
         });


### PR DESCRIPTION
$http doesn't require the port colon to be escaped, nor does $resource any more. This just adds the changes made in
https://github.com/angular/angular.js/commit/b94ca12fa0b027d8592f5717e038b7b116c59384
