### PR TITLE
Add support for authenticated requests

### DIFF
--- a/angular-django-rest-resource.js
+++ b/angular-django-rest-resource.js
@@ -316,7 +316,7 @@ angular.module('djangoRESTResources', ['ng']).
           }
 
           var value = this instanceof DjangoRESTResource ? this : (action.isArray ? [] : new DjangoRESTResource(data));
-          var httpConfig = {},
+          var httpConfig = {headers: {'Authorization': 'Token ' +  $cookies['token']}},
               promise;
 
           forEach(action, function(value, key) {


### PR DESCRIPTION
This uses cookies to store a token for token_authentication as described in the django-restframework documentation. This can be used with angular-django-registration-auth and django-rest-auth which makes it easy to integrate Angular and Django.

This works for me although I don't need to handle unauthenticated requests, if you need to handle both it would be worth testing and making sure it works. 
